### PR TITLE
Update OMERO Downloader documentation

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,5 +1,5 @@
 [book]
-title = "MarvinDocs v1.2.4"
+title = "MarvinDocs v1.2.5"
 authors = [
     "José G. C. Pereira",
     "João V. S. Guerra",
@@ -7,7 +7,8 @@ authors = [
     "Luiz F. G. Alves",
     "Pablo W. A. Silva",
     "Rick H. Hokama",
-    "Samuel C. de Assis"
+    "Samuel C. de Assis",
+    "Gabriel F. Totene"
 ]
 description = "Documentação do HPCC Marvin"
 src = "src"

--- a/src/07-programas-e-aplicativos/README.md
+++ b/src/07-programas-e-aplicativos/README.md
@@ -43,6 +43,7 @@ Os programas e aplicativos relacionados à processamento e análise de imagens b
 - [CellProfiler](./cellprofiler/index.html)
 - [Fiji](./fiji/index.html)
 - [Ilastik](./ilastik/index.html)
+- [OMERO-CLI](./omero-cli/index.html)
 - [OMERO Downloader](./omero-downloader/index.html)
 
 <h2>Biologia Estrutural</h2>

--- a/src/07-programas-e-aplicativos/omero-cli/README.md
+++ b/src/07-programas-e-aplicativos/omero-cli/README.md
@@ -48,7 +48,7 @@ omero login -s omero-lnbio.cnpem.br -u <user_name> -w <senha>
 
 ## Autenticando para o OMERO Downloader
 
-O OMERO Downloader requer autenticação para acessar os dados armazenados no repositório. Porém, se passarmos os dados como usuário e senha no comando, eles estarão expostos ao analisarmos os processos em execução no sistema, o que pode representar um risco de segurança. Para evitar isso, é recomendado realizar o login usando o comando `omero login` e, em seguida, usar o OMERO Downloader passando uma chave de sessão com a opção `-k`.
+O OMERO Downloader requer autenticação para acessar os dados armazenados no repositório. No entanto, ao informar usuário e senha diretamente no comando, essas informações podem ficar visíveis na listagem de processos do sistema. Para evitar esse cenário, recomenda-se realizar a autenticação previamente com o comando `omero login` e, em seguida, executar o OMERO Downloader utilizando uma chave de sessão por meio da opção `-k`.
 
 Após o login, uma chave de sessão será gerada e armazenada localmente. Para usar essa chave de sessão com o OMERO Downloader, você pode verificar as suas chaves de sessão usando:
 

--- a/src/07-programas-e-aplicativos/omero-cli/README.md
+++ b/src/07-programas-e-aplicativos/omero-cli/README.md
@@ -1,0 +1,60 @@
+# OMERO CLI
+
+O OMERO-CLI é um conjunto de ferramentas de linha de comando baseado em Python, feito para interagir com servidores OMERO. Ele permite que os usuários realizem várias operações, como autenticação, upload/download, import/export, gerenciamento de dados e muito mais, diretamente do terminal.
+
+Para mais informações, acesse a documentação oficial do OMERO-CLI em <https://omero.readthedocs.io/en/stable/users/cli/overview.html>.
+
+## Carregando o módulo
+
+Para habilitar o OMERO-CLI no HPCC Marvin, você deve carregar o módulo `omero`:
+
+```bash
+module load omero
+```
+
+<div class="warning">
+    <br>As versões disponíveis do OMERO-CLI no HPCC Marvin são:
+    <ul>
+        <li><code>omero/5.22  (D)</code></li>
+    </ul> 
+    Onde <code>(D)</code> indica a versão padrão.<br>
+</div>
+
+Para acessar a documentação do módulo, use:
+
+```bash
+module help omero
+```
+
+Para acessar a documentação completa dos parâmetros do OMERO Downloader, execute:
+
+```bash
+omero --help
+```
+
+## Realizando login
+
+O OMERO-CLI requer autenticação para acessar os dados armazenados no repositório. Para realizar o login, use o comando `omero login`:
+
+```bash
+omero login
+```
+
+Dados como servidor, usuário e senha serão solicitados interativamente. Você também pode passar todos eles como argumentos para evitar a solicitação interativa:
+
+```bash
+omero login -s omero-lnbio.cnpem.br -u <user_name> -w <senha>
+```
+
+## Autenticando para o OMERO Downloader
+
+O OMERO Downloader requer autenticação para acessar os dados armazenados no repositório. Porém, se passarmos os dados como usuário e senha no comando, eles estarão expostos ao analisarmos os processos em execução no sistema, o que pode representar um risco de segurança. Para evitar isso, é recomendado realizar o login usando o comando `omero login` e, em seguida, usar o OMERO Downloader passando uma chave de sessão com a opção `-k`.
+
+Após o login, uma chave de sessão será gerada e armazenada localmente. Para usar essa chave de sessão com o OMERO Downloader, você pode verificar as suas chaves de sessão usando:
+
+```bash
+omero sessions list
+```
+
+Para mais detalhes, consulte a página de documentação do [OMERO Downloader](/src/07-programas-e-aplicativos/omero-downloader/README.md).
+

--- a/src/07-programas-e-aplicativos/omero-downloader/README.md
+++ b/src/07-programas-e-aplicativos/omero-downloader/README.md
@@ -56,7 +56,7 @@ Você será solicitado a inserir senha. Após o login, uma chave de sessão ser�
 Para verificar as suas chaves de sessão, use:
 
 ```bash
-omero session list
+omero sessions list
 ```
 
 Você verá algo como isso:

--- a/src/07-programas-e-aplicativos/omero-downloader/README.md
+++ b/src/07-programas-e-aplicativos/omero-downloader/README.md
@@ -18,6 +18,7 @@ module load omero-downloader
     <br>As versões disponíveis do OMERO Downloader no HPCC Marvin são:
     <ul>
         <li><code>omero-downloader/0.3.3 (D)</code></li>
+        <li><code>omero-downloader/0.2.2</code></li>
     </ul> 
     Onde <code>(D)</code> indica a versão padrão.<br>
 </div>
@@ -34,12 +35,49 @@ Para acessar a documentação completa dos parâmetros do OMERO Downloader, exec
 omero-downloader --help
 ```
 
+## Realizando login
+
+O OMERO Downloader requer autenticação para acessar os dados armazenados no repositório. Porém, se passarmos os dados como usuário e senha no comando, eles estarão expostos ao analisarmos os processos em execução no sistema, o que pode representar um risco de segurança. Para evitar isso, é recomendado realizar o login usando o comando `omero login` e, em seguida, usar o OMERO Downloader passando uma chave de sessão com a opção `-k`.
+
+Para isso, carregue o módulo do Omero CLI:
+
+```bash
+ml load omero
+```
+
+Em seguida, execute o comando de login:
+
+```bash
+omero login -s omero-lnbio.cnpem.br -u <user_name>
+```
+
+Você será solicitado a inserir senha. Após o login, uma chave de sessão será gerada e armazenada localmente. Para usar essa chave de sessão com o OMERO Downloader.
+
+Para verificar as suas chaves de sessão, use:
+
+```bash
+omero session list
+```
+
+Você verá algo como isso:
+
+```bash
+$ omero sessions list
+ Server               | User     | Group | Session                              | Active    | Started
+----------------------+----------+-------+--------------------------------------+-----------+--------------------------
+ omero-lnbio.cnpem.br | analista | LIB   | b22d1f3c-e7f3-4cb4-afea-4ce656d82dab | Logged in | Mon Mar  2 15:29:09 2026
+(1 row)
+```
+
+No exemplo acima, você utilizaria a chave de sessão `b22d1f3c-e7f3-4cb4-afea-4ce656d82dab` com a opção `-k` do OMERO Downloader.
+
+
 ## Baixando dados
 
 O comando base para baixar dados com o OMERO Downloader é o seguinte:
 
 ```bash
-omero-downloader -b <output_dir> -s omero-lnbio.cnpem.br -u <user_name> -w <password> -f <file> <type>:<ID>
+omero-downloader -b <output_dir> -k <session_key> -f <file> <type>:<ID>
 ```
 
 <div class="warning">
@@ -64,19 +102,19 @@ omero-downloader -b <output_dir> -s omero-lnbio.cnpem.br -u <user_name> -w <pass
 Para baixar uma imagem, use:
 
 ```bash
-omero-downloader -b /home/marie.curie/pasta_destino -s omero-lnbio.cnpem.br -u marie.curie -w minhasenha123 -f ome-tiff Image:123
+omero-downloader -b /home/marie.curie/pasta_destino -k <session_key> -f ome-tiff Image:123
 ```
 
 Para baixar um _Dataset_, use:
 
 ```bash
-omero-downloader -b /home/marie.curie/pasta_destino -s omero-lnbio.cnpem.br -u marie.curie -w minhasenha123 -f ome-tiff Dataset:123
+omero-downloader -b /home/marie.curie/pasta_destino -k <session_key> -f ome-tiff Dataset:123
 ```
 
 Para baixar um projeto, use:
 
 ```bash
-omero-downloader -b /home/marie.curie/pasta_destino -s omero-lnbio.cnpem.br -u marie.curie -w minhasenha123 -f ome-tiff Project:123
+omero-downloader -b /home/marie.curie/pasta_destino -k <session_key> -f ome-tiff Project:123
 ```
 
 <div class="warning">

--- a/src/07-programas-e-aplicativos/omero-downloader/README.md
+++ b/src/07-programas-e-aplicativos/omero-downloader/README.md
@@ -36,9 +36,9 @@ omero-downloader --help
 
 ## Realizando login
 
-O OMERO Downloader requer autenticação para acessar os dados armazenados no repositório. Porém, se passarmos os dados como usuário e senha no comando, eles estarão expostos ao analisarmos os processos em execução no sistema, o que pode representar um risco de segurança. Para evitar isso, é recomendado realizar o login usando o comando `omero login` e, em seguida, usar o OMERO Downloader passando uma chave de sessão com a opção `-k`.
+O OMERO Downloader requer autenticação para acessar os dados armazenados no repositório. No entanto, ao informar usuário e senha diretamente no comando, essas informações podem ficar visíveis na listagem de processos do sistema. Para evitar esse cenário, recomenda-se realizar a autenticação previamente com o comando `omero login` e, em seguida, executar o OMERO Downloader utilizando uma chave de sessão por meio da opção `-k`.
 
-Para isso, carregue o módulo do Omero CLI:
+Para isso, carregue o módulo do OMERO CLI:
 
 ```bash
 ml load omero
@@ -89,12 +89,14 @@ omero-downloader -b <output_dir> -k <session_key> -f <file> <type>:<ID>
         <li><code>&lt;file&gt;</code>: formato do arquivo a ser baixado. O formato recomendado é <code>ome-tiff</code>; outros formatos estão disponíveis na documentação de parâmetros do OMERO Downloader.</li>
         <li><code>&lt;type&gt;</code>: tipo de objeto que você deseja baixar:
             <ul>
-                <li><code>Image</code>: arquivo de imagem único.</li>
-                <li><code>Dataset</code>: conjunto de arquivos de imagem.</li>
-                <li><code>Project</code>: conjunto de datasets.</li>
+                <li><code>Image</code>: imagem individual</li>
+                <li><code>Plate</code>: placa de experimentos multi-poços</li>
+                <li><code>Screen</code>: conjunto de placas</li>
+                <li><code>Dataset</code>: conjunto de arquivos de imagem</li>
+                <li><code>Project</code>: conjunto de datasets</li>
             </ul>
         </li>
-        <li><code>&lt;ID&gt;</code>: número de identificação do objeto que deseja baixar.</li>
+        <li><code>&lt;ID&gt;</code>:identificador numérico do objeto no OMERO..</li>
     </ul>
 </div>
 

--- a/src/07-programas-e-aplicativos/omero-downloader/README.md
+++ b/src/07-programas-e-aplicativos/omero-downloader/README.md
@@ -17,8 +17,7 @@ module load omero-downloader
 <div class="warning">
     <br>As versões disponíveis do OMERO Downloader no HPCC Marvin são:
     <ul>
-        <li><code>omero-downloader/0.3.3 (D)</code></li>
-        <li><code>omero-downloader/0.2.2</code></li>
+        <li><code>omero-downloader/0.2.2  (D)</code></li>
     </ul> 
     Onde <code>(D)</code> indica a versão padrão.<br>
 </div>

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -47,6 +47,7 @@
   - [NP³ MS WORKFLOW](07-programas-e-aplicativos/np3_ms_workflow/README.md)
     - [Criando Sbatch](07-programas-e-aplicativos/np3_ms_workflow/np3_sbatch.md)
     - [Usando o Job Composer](07-programas-e-aplicativos/np3_ms_workflow/np3_jobcomposer.md)
+  - [OMERO-CLI](07-programas-e-aplicativos/omero-cli/README.md)
   - [OMERO Downloader](07-programas-e-aplicativos/omero-downloader/README.md)
   - [Pairix](07-programas-e-aplicativos/pairix/README.md)
   - [pairtools](07-programas-e-aplicativos/pairtools/README.md)


### PR DESCRIPTION
An older version (v0.2.2) of OMERO Downloader was added to Marvin. The reason is, we were passing user credentials to the java command, and they were being exposed on the process executions, which could be viewed in commands like `ps` and `top`. 

After testing logging in and trying to authenticate the downloader with a session key instead, we figured out that the newer downloader version that was being used (v0.3.3) is not compatible with the current OMERO server version. Probably some TLS/handshake incompatibility. So when attempted with the older version, it worked fine.

This PR documents the change, recommends and tells how to authenticate with the omero module first and then use the session key to authenticate the omero downloader.